### PR TITLE
fix `AttributeError: module 'flux' has no attribute 'jobspec'`

### DIFF
--- a/src/psij/executors/flux.py
+++ b/src/psij/executors/flux.py
@@ -158,7 +158,7 @@ class FluxJobExecutor(JobExecutor):
         if spec.stdin_path:
             flux_jobspec.stdin = spec.stdin_path
         if spec.stderr_path:
-            flux.jobspec.stderr = spec.stderr_path
+            flux_jobspec.stderr = spec.stderr_path
         flux_jobspec.duration = spec.attributes.duration.total_seconds()
         fut = self._flux_executor.submit(flux_jobspec)
         self._add_flux_callbacks(job, fut)


### PR DESCRIPTION
Update `flux.py` to fix the following error: `AttributeError: module 'flux' has no attribute 'jobspec'`